### PR TITLE
[Feature] Disable rendering preview after it's been closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.1.2 - 2024-07-16
+
+### 🚀 Features
+
+* Do not render preview on file updates, if preview was closed before.
+
 ## 1.1.1 - 2024-07-03
 
-### Features
+### 🚀 Features
 
-* Close preview when document is closed
+* Close preview when document is closed.
 
-### Fixed
+### 🩹 Fixes
 
 * Invalidate cached render on manual render (button press).
 
 ## 1.1.0 - 2024-07-03
 
-### Features
+### 🚀 Features
 
 * Strip workspace folder from filenames in sidebar selector if there's only 1 opened workspace folder.
 
@@ -22,10 +28,10 @@ All notable changes to this project will be documented in this file.
 
 ## 1.0.2 - 2024-07-02
 
-### Fixed
+### 🩹 Fixes
 
-* No more automatically render any file that was just opened but wasn't rendered before
+* No more automatically render any file that was just opened but wasn't rendered before.
 
 ## 1.0.0 - 2024-07-02
 
-Initial release of helmfile preview
+Initial release of helmfile preview.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "helmfile",
     "helmfile-template"
   ],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "LICENSE.md",
   "icon": "media/helmfile.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,20 +69,6 @@ export function activate(context: vscode.ExtensionContext) {
     }
   }));
 
-  // vscode.window.onDidChangeActiveTextEditor(
-  // ! Troubled behavior
-  //   async (e) => {
-  //     const uri = vscode.Uri.parse(`${HelmfileTemplateFileProvider.scheme}://${e?.document.uri.fsPath}`);
-  //     const document = await vscode.workspace.openTextDocument(uri);
-  //     await vscode.window.showTextDocument(document, {
-  //       preview: true,
-  //       preserveFocus: true,
-  //       viewColumn: vscode.ViewColumn.Beside
-  //     });
-  //     vscode.languages.setTextDocumentLanguage(document, "yaml");
-  //   }
-  // );
-
   //SidebarProvider
   const sidebarProvider = new SidebarProvider(context.extensionUri);
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { SidebarProvider } from './providers/sidebarProvider';
 import { HelmfileTemplateFileProvider } from "./providers/helmfileTemplateFileProvider";
 import { openCurrentPreview } from './commands/openCurrentPreview';
 import { findFirstAndPreview } from './commands/findFirstAndPreview';
+import { getNonce } from "./utilities/getNonce";
 
 export function activate(context: vscode.ExtensionContext) {
   // Commands
@@ -20,28 +21,54 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidSaveTextDocument(
     async (doc) => {
-      if (doc.uri.fsPath === HelmfileTemplateFileProvider.currentlyRendered)
-        {
-          HelmfileTemplateFileProvider.render(doc.uri.fsPath);
-        }
+      if (HelmfileTemplateFileProvider.currentlyRendered.includes(doc.uri.fsPath))
+      {
+        HelmfileTemplateFileProvider.render(doc.uri.fsPath, undefined, undefined, undefined, getNonce());
+      }
     }
   );
 
   vscode.workspace.onDidCloseTextDocument(async event => {
-    if (event.uri.fsPath === HelmfileTemplateFileProvider.currentlyRendered) {
+    if (HelmfileTemplateFileProvider.currentlyRendered.includes(event.uri.fsPath)) {
       const previewTabGroup = vscode.window.tabGroups.all;
 
       let previewTab;
       let i = 0;
       while (!previewTab || previewTab.length === 0) {
         previewTab = previewTabGroup[i].tabs.filter(tab =>
-          (tab.input instanceof vscode.TabInputText) && (tab.input.uri.fsPath === HelmfileTemplateFileProvider.currentlyRendered) && (tab.input.uri.scheme === "htvf")
+          (tab.input instanceof vscode.TabInputText) && (HelmfileTemplateFileProvider.currentlyRendered.includes(tab.input.uri.fsPath)) && (tab.input.uri.scheme === "htvf")
         );
         i++;
       }
       await vscode.window.tabGroups.close(previewTab, false);
+      HelmfileTemplateFileProvider.currentlyRendered = "";
     }
   });
+
+  const openEditors = new Set<string>();
+
+  context.subscriptions.push(vscode.window.onDidChangeVisibleTextEditors((editors) => {
+    const currentOpenEditors = new Set(editors.map(editor => editor.document.uri.toString()));
+
+    for (const uriString of openEditors) {
+      if (!currentOpenEditors.has(uriString)) {
+        if(uriString.startsWith(HelmfileTemplateFileProvider.scheme)){
+          HelmfileTemplateFileProvider.currentlyRendered = "";
+        }
+        openEditors.delete(uriString);
+      }
+    }
+
+    for (const uriString of currentOpenEditors) {
+      if (!openEditors.has(uriString)) {
+        if (uriString.startsWith(HelmfileTemplateFileProvider.scheme)) {
+          HelmfileTemplateFileProvider.currentlyRendered = uriString.replace(`${HelmfileTemplateFileProvider.scheme}:`, "");
+        }
+        openEditors.add(uriString);
+      }
+    }
+  }));
+
   // vscode.window.onDidChangeActiveTextEditor(
   // ! Troubled behavior
   //   async (e) => {


### PR DESCRIPTION
If preview has been closed, but original helmfile was updated, extension will render it again even though user has closed the preview.
This PR mitigate described behavior.