### PR TITLE
[FIX] Avoid triggering hooks and installing CRDs during rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.3] - 2024-07-28
+
+### 🩹 Fixes
+
+* Disable hooks run and CRDs install during rendering preview.
+
 ## [1.1.2] - 2024-07-16
 
 ### 🚀 Features

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "helmfile",
     "helmfile-template"
   ],
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "LICENSE.md",
   "icon": "media/helmfile.png",
   "engines": {

--- a/src/providers/helmfileTemplateFileProvider.ts
+++ b/src/providers/helmfileTemplateFileProvider.ts
@@ -75,7 +75,7 @@ export class HelmfileTemplateFileProvider implements vscode.TextDocumentContentP
     const prerun = args.prerun !== "undefined" ? `${args.prerun} && ` : "";
 
     try {
-      const command = `${prerun}${helmfileBinary} template --file ${helmFileAbsPath} ${env} ${selectros} ${debug} ${helm}`;
+      const command = `${prerun}${helmfileBinary} template --args='--no-hooks --skip-crds' --file ${helmFileAbsPath} ${env} ${selectros} ${debug} ${helm}`;
       console.log(`helmfile exec command: ${command}`);
       HelmfileTemplateFileProvider.currentlyRendered = helmFileAbsPath;
 


### PR DESCRIPTION
If there were hooks in your charts, it would be triggered by running `helmfile template`.